### PR TITLE
When scaling se by p-value and pval = 1 we do division by zero which

### DIFF
--- a/python/make_finemap_inputs.py
+++ b/python/make_finemap_inputs.py
@@ -134,7 +134,7 @@ def read_sumstats(path,
 
     if scale_se_by_pval:
         se = np.abs(sumstats.beta / stats.norm.ppf(sumstats.p.astype(float) / 2))
-        se[(sumstats.beta == 0) | np.isnan(se)] = sumstats.se[(sumstats.beta == 0) | np.isnan(se)]
+        se[(sumstats.beta == 0) | np.isnan(se) | np.isinf(se)] = sumstats.se[(sumstats.beta == 0) | np.isnan(se) | np.isinf(se)]
         logger.info("{} SNPs are scaled (--scale-se-by-pval)".format(np.sum(~np.isclose(sumstats.se, se))))
         sumstats['se'] = se
 

--- a/python/make_finemap_inputs.py
+++ b/python/make_finemap_inputs.py
@@ -134,7 +134,7 @@ def read_sumstats(path,
 
     if scale_se_by_pval:
         se = np.abs(sumstats.beta / stats.norm.ppf(sumstats.p.astype(float) / 2))
-        se[(sumstats.beta == 0) | np.isnan(se) | np.isinf(se)] = sumstats.se[(sumstats.beta == 0) | np.isnan(se) | np.isinf(se)]
+        se[(sumstats.beta == 0) | ~np.isfinite(se)] = sumstats.se[(sumstats.beta == 0) | ~np.isfinite(se)]
         logger.info("{} SNPs are scaled (--scale-se-by-pval)".format(np.sum(~np.isclose(sumstats.se, se))))
         sumstats['se'] = se
 


### PR DESCRIPTION
surprisingly is inf in numpy. Fixed so that inf ses are replaced by
originals ones