### PR TITLE
Improved region definition with recursive window shrinkage

### DIFF
--- a/python/make_finemap_inputs.py
+++ b/python/make_finemap_inputs.py
@@ -218,12 +218,9 @@ def generate_bed(sumstats,
                 # keep in-size regions
                 bed1 = bed.filter(lambda x: len(x) <= max_region_width).saveas()
                 
-                # filter to oversized regions
-                sumstats = map(lambda x: filter_sumstat(x, bed_oversized), sumstats)
-
                 # recursion with current window size * window_shrink_ratio
                 bed2, lead_snps2 = generate_bed(
-                    sumstats,
+                    map(lambda x: filter_sumstat(x, bed_oversized), sumstats),
                     p_threshold=p_threshold,
                     maf_threshold=maf_threshold,
                     window=window * window_shrink_ratio,


### PR DESCRIPTION
I implemented a new region definition method.

Currently, regions are defined by the following steps:
1. Starting from the most significant variant, we add a flanking window (default: 1.5 Mb upstream and downstream) around the index variant to define a region
2. Remove variants in the region, and repeat the first step until none remains
3. Merge regions if they overlap.
4. If `--max-region-width` (default: 6 Mb) is supplied, any regions that exceed the size will be split into multiple regions, just by consecutively taking 6Mb regions from the beginning.

Here, the fourth step could be problematic because it does not consider association significance -- e.g., the lead variant in a large region might be around 6 Mb; and thus its LD neighbors will be split into separate regions.

In this PR, I replaced the fourth step with the following:
4. If `--max-region-width` (default: 6 Mb) is supplied, any regions that exceed the size will repeat the first step with a shrunken window size (default: current window size * 0.9) -- and continue the steps 1-4 until none exceeds the maximum size.

I think this implementation is better than 1) the current implementation because this considers association significance when splitting; and better than 2) using a shorter window size because this only splits a region that exceeds the maximum size.

Technically, this is implemented by recursively calling `generate_bed` function which is more intuitive than having a separate `split` function.