### PR TITLE
fix a bug in filter_sumstat

### DIFF
--- a/python/make_finemap_inputs.py
+++ b/python/make_finemap_inputs.py
@@ -146,9 +146,9 @@ def read_sumstats(path,
     return sumstats
 
 def filter_sumstat(df, bed):
-    for f in bed:
-        df = df.loc[((df.chromosome == f.chrom) & (df.position >= f.start) & (df.position <= f.end)), :]
-    return df
+    return pd.concat(
+        [df.loc[((df.chromosome == f.chrom) & (df.position >= f.start) & (df.position <= f.end)), :] for f in bed]
+    )
 
 
 def generate_bed(sumstats,


### PR DESCRIPTION
This PR fixes a bug in `filter_sumtat` that returns an empty dataframe when there are multiple oversized regions exist.