### PR TITLE
Add output section to wdl, making getting outputs easier

### DIFF
--- a/wdl/finemap.wdl
+++ b/wdl/finemap.wdl
@@ -116,4 +116,25 @@ workflow finemap {
         }
 
     }
+
+    output {
+        Array[File] bed = preprocess.bed 
+        Array[Boolean] had_results = preprocess.had_results
+        Array[File] out_susie_snp_filtered = select_all(ldstore_finemap.out_susie_snp_filtered)
+        Array[File] out_susie_cred_summary = select_all(ldstore_finemap.out_susie_cred_summary)
+        Array[File] out_susie_snp_filtered_99 = select_all(ldstore_finemap.out_susie_snp_filtered_99)
+        Array[File] out_susie_cred_summary_99 = select_all(ldstore_finemap.out_susie_cred_summary_99)
+        Array[File] out_susie_snp_filtered_extend = select_all(ldstore_finemap.out_susie_snp_filtered_extend)
+        Array[File] out_susie_cred_summary_extend = select_all(ldstore_finemap.out_susie_cred_summary_extend)
+        Array[File] out_susie_snp = select_all(ldstore_finemap.out_susie_snp)
+        Array[File] out_susie_snp_tbi = select_all(ldstore_finemap.out_susie_snp_tbi)
+        Array[File] out_susie_cred = select_all(ldstore_finemap.out_susie_cred)
+        Array[File] out_susie_cred_99 = select_all(ldstore_finemap.out_susie_cred_99)
+
+        Array[Array[File]] out_susie_rds = select_all(ldstore_finemap.out_susie_rds)
+        Array[File] out_finemap_snp = select_all(ldstore_finemap.out_finemap_snp)
+        Array[File] out_finemap_snp_tbi = select_all(ldstore_finemap.out_finemap_snp_tbi)
+        Array[File] out_finemap_config = select_all(ldstore_finemap.out_finemap_config)
+        Array[File] out_finemap_region = select_all(ldstore_finemap.out_finemap_region)
+    }
 }

--- a/wdl/finemap_sub.wdl
+++ b/wdl/finemap_sub.wdl
@@ -685,4 +685,22 @@ workflow ldstore_finemap {
             susie_cred_99=combine.out_susie_cred_99, set_variant_id_map_chr=set_variant_id_map_chr
     }
 
+    output{
+        File out_susie_snp_filtered = filter_and_summarize.out_susie_snp_filtered
+        File out_susie_cred_summary = filter_and_summarize.out_susie_cred_summary
+        File out_susie_snp_filtered_99 = filter_and_summarize.out_susie_snp_filtered_99
+        File out_susie_cred_summary_99 = filter_and_summarize.out_susie_cred_summary_99
+        File out_susie_snp_filtered_extend = filter_and_summarize.out_susie_snp_filtered_extend
+        File out_susie_cred_summary_extend = filter_and_summarize.out_susie_cred_summary_extend
+        File out_susie_snp = combine.out_susie_snp
+        File out_susie_snp_tbi = combine.out_susie_snp_tbi
+        File out_susie_cred = combine.out_susie_cred
+        File out_susie_cred_99 = combine.out_susie_cred_99
+        Array[File] out_susie_rds = susie.rds
+        File out_finemap_snp = combine.out_finemap_snp
+        File out_finemap_snp_tbi = combine.out_finemap_snp_tbi
+        File out_finemap_config = combine.out_finemap_config
+        File out_finemap_region = combine.out_finemap_region
+    }
+
 }


### PR DESCRIPTION
Sometimes the finemapping outputs can be scattered around multiple runs, e.g. if cromwell crashes when running the pipeline or if there are other problems in the machinery. This is no big deal, but makes copying outputs to buckets tedious, as one needs to make as many gsutil calls as there are reruns. This in addition to separating analysis steps into a few different runs to lessen the load to cromwell means that copying stuff from workflows can be a big hurdle.

Thankfully, cromwell has a solution: if one implements an outputs-section in the workflow, one can download a list of the outputs (in json) from swagger /outputs-endpoint.

This PR implements that section for both the main workflow and the subworkflow. most outputs are included, like combined files, susie summaries, and susie rds files.