### PR TITLE
add *.cred* files to wdl outputs

### DIFF
--- a/wdl/finemap.wdl
+++ b/wdl/finemap.wdl
@@ -132,6 +132,7 @@ workflow finemap {
         Array[File] out_susie_cred_99 = select_all(ldstore_finemap.out_susie_cred_99)
 
         Array[Array[File]] out_susie_rds = select_all(ldstore_finemap.out_susie_rds)
+        Array[Array[Array[File]]] out_finemap_cred_regions = select_all(ldstore.finemap_cred_regions)
         Array[File] out_finemap_snp = select_all(ldstore_finemap.out_finemap_snp)
         Array[File] out_finemap_snp_tbi = select_all(ldstore_finemap.out_finemap_snp_tbi)
         Array[File] out_finemap_config = select_all(ldstore_finemap.out_finemap_config)

--- a/wdl/finemap_sub.wdl
+++ b/wdl/finemap_sub.wdl
@@ -697,6 +697,7 @@ workflow ldstore_finemap {
         File out_susie_cred = combine.out_susie_cred
         File out_susie_cred_99 = combine.out_susie_cred_99
         Array[File] out_susie_rds = susie.rds
+        Array[Array[File]] finemap_cred_regions = finemap.cred_files
         File out_finemap_snp = combine.out_finemap_snp
         File out_finemap_snp_tbi = combine.out_finemap_snp_tbi
         File out_finemap_config = combine.out_finemap_config


### PR DESCRIPTION
we use the FINEMAP regional files (*.credN, where N=how many assumed signals in region) in our downstream analyses. Adding those to the outputs makes it easier to grab them.