### PR TITLE
Fix --exclude-MHC

### DIFF
--- a/wdl/finemap_inputs.json
+++ b/wdl/finemap_inputs.json
@@ -1,6 +1,6 @@
 {
     "finemap.zones": "europe-west1-b europe-west1-c europe-west1-d",
-    "finemap.docker": "eu.gcr.io/finngen-refinery-dev/finemap-suite:ed26d2c",
+    "finemap.docker": "eu.gcr.io/finngen-refinery-dev/finemap-suite:7cebc90",
     "finemap.sumstats_pattern": "gs://finngen-production-library-green/finngen_R7/finngen_R7_analysis_data/summary_stats/release/finngen_R7_{PHENO}.gz",
     "finemap.phenolistfile": "gs://r7_data/finemap/demopheno/conf/extended_demopheno",
     "finemap.phenotypes": "gs://r7_data/pheno/R7_COV_PHENO_V2.txt.gz",


### PR DESCRIPTION
This addresses #36. Instead of filtering all the variants in MHC before adding windows, this fix will exclude regions overlapping with the MHC so that the edge case described in #36 won't happen.