### PR TITLE
change faulty susie docker image

### DIFF
--- a/wdl/finemap_inputs.json
+++ b/wdl/finemap_inputs.json
@@ -33,7 +33,7 @@
     "finemap.ldstore_finemap.finemap.cpu": 8,
     "finemap.ldstore_finemap.finemap.mem": 52,
     "finemap.ldstore_finemap.susie.min_cs_corr": 0,
-    "finemap.ldstore_finemap.susie.docker": "eu.gcr.io/finngen-refinery-dev/susie:0.11.55.5333382",
+    "finemap.ldstore_finemap.susie.docker": "eu.gcr.io/finngen-refinery-dev/susie:0.11.92.2360607",
     "finemap.ldstore_finemap.susie.cpu": 8,
     "finemap.ldstore_finemap.susie.mem": 208,
     "finemap.ldstore_finemap.combine.cpu": 1,


### PR DESCRIPTION
finemap_inputs.json had a faulty susie docker image, which did not calculate R2 correctly. This PR fixes that.