### PR TITLE
add 'set -eux' to combine to trap errors

### DIFF
--- a/wdl/finemap_sub.wdl
+++ b/wdl/finemap_sub.wdl
@@ -243,7 +243,7 @@ task combine {
     Int mem
 
     command <<<
-
+        set -eux
         cat << "__EOF__" > combine_snp.awk
         BEGIN {
             OFS = "\t"


### PR DESCRIPTION
This should make combine fail if e.g. disk runs out