### PR TITLE
cast 1.0 to 1 so binary phenos coded as 1.0 and 0.0 work

### DIFF
--- a/wdl/finemap.wdl
+++ b/wdl/finemap.wdl
@@ -56,7 +56,7 @@ task preprocess {
             }
         }
         NR > 1 && $h[ph] != "NA" {
-            vals[$h[ph]] += 1
+            vals[$h[ph] + 0] += 1
             print $1 > ph".incl"
             if ($h[ph] != 0 && $h[ph] != 1 && !err) {
                 print "Phenotype:"ph" seems a quantitative trait. Setting var_y = 1 and prior_std = 0.05." > "/dev/stderr"


### PR DESCRIPTION
coding of binary phenos was assumed to be 1 and 0, this allows 1.0 and 0.0 to work too (pandas gives 1.0 and 0.0 if not explicitly casted)