### PR TITLE
fix hardcoded cromwell root

### DIFF
--- a/wdl/finemap_sub.wdl
+++ b/wdl/finemap_sub.wdl
@@ -8,7 +8,7 @@ task ldstore {
     String prefix = basename(zfile, ".z")
     String chrom = sub(sub(prefix, pheno + "\\.chr", ""), "\\.[0-9\\-]+$", "")
     String bgenbucket = sub(sub(bgen_pattern, "^gs://", ""), "/.+$", "")
-    String mountpoint = "/cromwell_root/gcsfuse/" + bgenbucket
+    String mountpoint = bgenbucket
     String bgen = sub(sub(bgen_pattern, "\\{CHR\\}", chrom), "^gs://" + bgenbucket, mountpoint)
     String bgen_gs = sub(bgen_pattern, "\\{CHR\\}", chrom)
     File bgi = sub(bgen_pattern, "\\{CHR\\}", chrom) + ".bgi"

--- a/wdl/sandbox_pipeline/finemap_sub.wdl
+++ b/wdl/sandbox_pipeline/finemap_sub.wdl
@@ -8,7 +8,7 @@ task ldstore {
     String prefix = basename(zfile, ".z")
     String chrom = sub(sub(prefix, pheno + "\\.chr", ""), "\\.[0-9\\-]+$", "")
     String bgenbucket = sub(sub(chromosome_bgen_map[chrom], "^gs://", ""), "/.+$", "")
-    String mountpoint = "/cromwell_root/gcsfuse/" + bgenbucket
+    String mountpoint = bgenbucket
     String bgen = sub(chromosome_bgen_map[chrom], "^gs://" + bgenbucket, mountpoint)
     String bgen_gs = chromosome_bgen_map[chrom]
     File bgi = chromosome_bgen_map[chrom] + ".bgi"


### PR DESCRIPTION
Hardcoded cromwell root does not work on batch, since the root dir changed. It might change in the future and is an implementation detail of the batch backend, so instead, we should not rely on it. This PR removes the hardcoded folder, and instead uses a relative folder to where the script is executed. 