### PR TITLE
Fix sandbox modifiable pipeline

### DIFF
--- a/wdl/sandbox_pipeline/finemap_sub.wdl
+++ b/wdl/sandbox_pipeline/finemap_sub.wdl
@@ -74,10 +74,10 @@ task ldstore {
         docker: "${docker}"
         cpu: "${cpu}"
         memory: "${mem} GB"
-        disks: "local-disk 200 HDD"
+        disks: "local-disk 400 HDD"
         zones: "${zones}"
         preemptible: 2
-        noAddress: false
+        noAddress: true
     }
 }
 
@@ -531,7 +531,7 @@ task filter_and_summarize{
         docker: "${docker}"
         cpu: "${cpu}"
         memory: "${mem} GB"
-        disks: "local-disk 60 HDD"
+        disks: "local-disk 120 HDD"
         zones: "${zones}"
         preemptible: 2
         noAddress: true


### PR DESCRIPTION
Changes related to errors in sandbox
- Change ldstore task to noaddress:true, since we can't use gcsfuse anyways, and this was failing some tasks.
- Add disk space for the ldstore task, since in some cases it was running out.